### PR TITLE
Support for specific module IDs

### DIFF
--- a/MMM-ModuleToggle.js
+++ b/MMM-ModuleToggle.js
@@ -39,28 +39,29 @@ Module.register("MMM-ModuleToggle",{
 
             var callback = function(){};
             var options = {lockString: self.identifier};
+            
+            console.log(module.name);
 
-            if (true) { // modulesList.includes(module.name)
-                console.log(module.name);
-                switch(type){
-                case "hide":
-                    Log.log("Hide "+ module.name);
-                    module.hide(self.config.speed, callback, options);
-                    break;
-                case "show":
-                    Log.log("Show "+ module.name);
-                    module.show(self.config.speed, callback, options);
-                    break;
-                case "toggle":
-                    Log.log("Toggle "+ module.name);
-                    if(module.hidden){
-                        module.show(self.config.speed, callback, options);
-                    }else{
-                        module.hide(self.config.speed, callback, options);
-                    }
-                    break;
-            }
-            }
+//            if (true) { // modulesList.includes(module.name)
+//                switch(type){
+//                case "hide":
+//                    Log.log("Hide "+ module.name);
+//                    module.hide(self.config.speed, callback, options);
+//                    break;
+//                case "show":
+//                    Log.log("Show "+ module.name);
+//                    module.show(self.config.speed, callback, options);
+//                    break;
+//                case "toggle":
+//                    Log.log("Toggle "+ module.name);
+//                    if(module.hidden){
+//                        module.show(self.config.speed, callback, options);
+//                    }else{
+//                        module.hide(self.config.speed, callback, options);
+//                    }
+//                    break;
+//            }
+//            }
             
         });
         

--- a/MMM-ModuleToggle.js
+++ b/MMM-ModuleToggle.js
@@ -40,7 +40,7 @@ Module.register("MMM-ModuleToggle",{
             var callback = function(){};
             var options = {lockString: self.identifier};
             
-            console.log(module.id);
+            console.log(module);
 
 //            if (true) { // modulesList.includes(module.name)
 //                switch(type){

--- a/MMM-ModuleToggle.js
+++ b/MMM-ModuleToggle.js
@@ -24,6 +24,8 @@ Module.register("MMM-ModuleToggle",{
         
         self.config.notifications.forEach(function(item){
             if (notification === item.notification) {
+                self.changeModuleState(item.hide, "hide", self.config.speed);
+                self.changeModuleState(item.show, "show", self.config.speed);
                 self.changeModuleState(item.toggle, "toggle", self.config.speed);
             }
             

--- a/MMM-ModuleToggle.js
+++ b/MMM-ModuleToggle.js
@@ -1,4 +1,3 @@
-
 Module.register("MMM-ModuleToggle",{
     requiresVersion: "2.1.0",
     defaults: {
@@ -34,14 +33,16 @@ Module.register("MMM-ModuleToggle",{
     },
     
     changeModuleState: function(modulesList, type = "hide"){
-        var modulesToHide = MM.getModules().withClass(modulesList);
+        var modulesToHide = MM.getModules();
             
         modulesToHide.enumerate(function(module) {
 
             var callback = function(){};
             var options = {lockString: self.identifier};
-            
-            switch(type){
+
+            if (true) { // modulesList.includes(module.name)
+                console.log(module.name);
+                switch(type){
                 case "hide":
                     Log.log("Hide "+ module.name);
                     module.hide(self.config.speed, callback, options);
@@ -58,6 +59,7 @@ Module.register("MMM-ModuleToggle",{
                         module.hide(self.config.speed, callback, options);
                     }
                     break;
+            }
             }
             
         });

--- a/MMM-ModuleToggle.js
+++ b/MMM-ModuleToggle.js
@@ -40,7 +40,7 @@ Module.register("MMM-ModuleToggle",{
             var callback = function(){};
             var options = {lockString: self.identifier};
             
-            console.log(module.name);
+            console.log(module.id);
 
 //            if (true) { // modulesList.includes(module.name)
 //                switch(type){

--- a/MMM-ModuleToggle.js
+++ b/MMM-ModuleToggle.js
@@ -9,7 +9,7 @@ Module.register("MMM-ModuleToggle",{
         var self = this;
         
         if (notification === 'DOM_OBJECTS_CREATED'){
-            self.changeModuleState(self.config.hide, "hide");
+            self.changeModuleState(self.config.hide, "hide", self.config.speed);
         }
         
 
@@ -17,44 +17,42 @@ Module.register("MMM-ModuleToggle",{
             
             Log.log(self.name + " received a module notification: " + notification + " from sender: " + sender.name);
             
-            self.changeModuleState(payload.hide, "hide");
-            self.changeModuleState(payload.show, "show");
-            self.changeModuleState(payload.toggle, "toggle");
+            self.changeModuleState(payload.hide, "hide", self.config.speed);
+            self.changeModuleState(payload.show, "show", self.config.speed);
+            self.changeModuleState(payload.toggle, "toggle", self.config.speed);
         }
         
         self.config.notifications.forEach(function(item){
             if (notification === item.notification) {
-                self.changeModuleState(item.toggle, "toggle");
+                self.changeModuleState(item.toggle, "toggle", self.config.speed);
             }
             
         });
     },
     
-    changeModuleState: function(modulesList, type = "hide"){
+    changeModuleState: function(modulesList, type = "hide", speed){
         var modulesToHide = MM.getModules();
             
         modulesToHide.enumerate(function(module) {
 
             var callback = function(){};
             var options = {lockString: self.identifier};
-            console.log(modulesList);
-            console.log(modulesList.includes(module.identifier));
             if (modulesList.includes(module.name) || modulesList.includes(module.identifier)) {
                 switch(type){
                 case "hide":
                     Log.log("Hide "+ module.name);
-                    module.hide(self.config.speed, callback, options);
+                    module.hide(speed, callback, options);
                     break;
                 case "show":
                     Log.log("Show "+ module.name);
-                    module.show(self.config.speed, callback, options);
+                    module.show(speed, callback, options);
                     break;
                 case "toggle":
                     Log.log("Toggle "+ module.name);
                     if(module.hidden){
-                        module.show(self.config.speed, callback, options);
+                        module.show(speed, callback, options);
                     }else{
-                        module.hide(self.config.speed, callback, options);
+                        module.hide(speed, callback, options);
                     }
                     break;
             }

--- a/MMM-ModuleToggle.js
+++ b/MMM-ModuleToggle.js
@@ -39,7 +39,7 @@ Module.register("MMM-ModuleToggle",{
 
             var callback = function(){};
             var options = {lockString: self.identifier};
-            console.log(modulesList.includes(module.name));
+            console.log(modulesList);
             console.log(modulesList.includes(module.identifier));
             if (modulesList.includes(module.name) || modulesList.includes(module.identifier)) {
                 switch(type){

--- a/MMM-ModuleToggle.js
+++ b/MMM-ModuleToggle.js
@@ -39,8 +39,9 @@ Module.register("MMM-ModuleToggle",{
 
             var callback = function(){};
             var options = {lockString: self.identifier};
-
-            if (modulesList.includes(module.name) || modulesList.includes(module.identifier)) { 
+            console.log(modulesList.includes(module.name));
+            console.log(modulesList.includes(module.identifier));
+            if (modulesList.includes(module.name) || modulesList.includes(module.identifier)) {
                 switch(type){
                 case "hide":
                     Log.log("Hide "+ module.name);

--- a/MMM-ModuleToggle.js
+++ b/MMM-ModuleToggle.js
@@ -40,7 +40,7 @@ Module.register("MMM-ModuleToggle",{
             var callback = function(){};
             var options = {lockString: self.identifier};
             
-            console.log(module);
+            console.log(module.identifier);
 
 //            if (true) { // modulesList.includes(module.name)
 //                switch(type){

--- a/MMM-ModuleToggle.js
+++ b/MMM-ModuleToggle.js
@@ -24,8 +24,6 @@ Module.register("MMM-ModuleToggle",{
         
         self.config.notifications.forEach(function(item){
             if (notification === item.notification) {
-                self.changeModuleState(item.hide, "hide");
-                self.changeModuleState(item.show, "show");
                 self.changeModuleState(item.toggle, "toggle");
             }
             

--- a/MMM-ModuleToggle.js
+++ b/MMM-ModuleToggle.js
@@ -39,29 +39,27 @@ Module.register("MMM-ModuleToggle",{
 
             var callback = function(){};
             var options = {lockString: self.identifier};
-            
-            console.log(module.identifier);
 
-//            if (true) { // modulesList.includes(module.name)
-//                switch(type){
-//                case "hide":
-//                    Log.log("Hide "+ module.name);
-//                    module.hide(self.config.speed, callback, options);
-//                    break;
-//                case "show":
-//                    Log.log("Show "+ module.name);
-//                    module.show(self.config.speed, callback, options);
-//                    break;
-//                case "toggle":
-//                    Log.log("Toggle "+ module.name);
-//                    if(module.hidden){
-//                        module.show(self.config.speed, callback, options);
-//                    }else{
-//                        module.hide(self.config.speed, callback, options);
-//                    }
-//                    break;
-//            }
-//            }
+            if (modulesList.includes(module.name) || modulesList.includes(module.identifier)) { 
+                switch(type){
+                case "hide":
+                    Log.log("Hide "+ module.name);
+                    module.hide(self.config.speed, callback, options);
+                    break;
+                case "show":
+                    Log.log("Show "+ module.name);
+                    module.show(self.config.speed, callback, options);
+                    break;
+                case "toggle":
+                    Log.log("Toggle "+ module.name);
+                    if(module.hidden){
+                        module.show(self.config.speed, callback, options);
+                    }else{
+                        module.hide(self.config.speed, callback, options);
+                    }
+                    break;
+            }
+            }
             
         });
         


### PR DESCRIPTION
I have found a way to add specific module IDs to toggle. This is extremely helpful if you have multiple instances of the same module. The syntax is similar:
toggle: {"Clock", "module_5_MMM-GoogleTasks", "module_6_MMM-GoogleTasks"}
This would toggle the clock and the Google Tasks modules 5 and 6, leaving the other Google Tasks modules alone.